### PR TITLE
Add query builders for 'search by generator'

### DIFF
--- a/src/Model/SearchResult.php
+++ b/src/Model/SearchResult.php
@@ -2,7 +2,7 @@
 
 namespace Elucidate\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use ArrayIterator;
 use Elucidate\Search\SearchCustom;
 
 class SearchResult
@@ -38,10 +38,10 @@ class SearchResult
     public function getResults()
     {
         if (!$this->container['first']) {
-            return new ArrayCollection();
+            return new ArrayIterator([]);
         }
 
         $items = $this->container['first']['items'];
-        return new ArrayCollection(array_map([Annotation::class, 'fromArray'], $items));
+        return new ArrayIterator(array_map([Annotation::class, 'fromArray'], $items));
     }
 }

--- a/src/Model/SearchResult.php
+++ b/src/Model/SearchResult.php
@@ -2,6 +2,7 @@
 
 namespace Elucidate\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Elucidate\Search\SearchCustom;
 
 class SearchResult
@@ -11,6 +12,16 @@ class SearchResult
     public function __construct(Container $container)
     {
         $this->container = $container;
+    }
+
+    public static function fromArray(array $data): SearchResult
+    {
+        return new static(Container::fromArray($data));
+    }
+
+    public static function fromJson(string $json): SearchResult
+    {
+        return new static(Container::fromJson($json));
     }
 
     /** @return SearchCustom|null */
@@ -27,20 +38,10 @@ class SearchResult
     public function getResults()
     {
         if (!$this->container['first']) {
-            return;
+            return new ArrayCollection();
         }
-        foreach ($this->container['first']['items'] as $item) {
-            yield Annotation::fromArray($item);
-        }
-    }
 
-    public static function fromArray(array $data) : SearchResult
-    {
-        return new static(Container::fromArray($data));
-    }
-
-    public static function fromJson(string $json) : SearchResult
-    {
-        return new static(Container::fromJson($json));
+        $items = $this->container['first']['items'];
+        return new ArrayCollection(array_map([Annotation::class, 'fromArray'], $items));
     }
 }

--- a/src/Search/AnnotationQueryBuilder.php
+++ b/src/Search/AnnotationQueryBuilder.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Elucidate\Search;
+
+use Assert\Assertion;
+
+final class AnnotationQueryBuilder
+{
+    use StrictQueryAware;
+
+    /**
+     * Relative path to the annotation body search service.
+     */
+    const SEARCH_BODY_SERVICE_PATH = '/services/search/body';
+
+    /**
+     * Relative path to the annotation target search service.
+     */
+    const SEARCH_TARGET_SERVICE_PATH = '/services/search/target';
+
+    /**
+     * @var string
+     */
+    private $creator;
+
+    /**
+     * The list of fields to be compared for this query.
+     *
+     * @var string[]
+     */
+    private $fields;
+
+    /**
+     * @var string
+     */
+    private $generator;
+
+    /**
+     * The relative path of the search service this query targets.
+     *
+     * @var string
+     */
+    private $path;
+
+    /**
+     * A media fragment spatial selector to filter annotations that intersect with the given dimensions.
+     *
+     * @var string
+     */
+    private $spatialSelector;
+
+    /**
+     * A flag indicating whether a strict comparison should be made between the subject and {@code value}.
+     *
+     * @var bool
+     */
+    private $strict = false;
+
+    /**
+     * A media fragment temporal selector to filter annotations that intersect with the given time period.
+     *
+     * @var string
+     */
+    private $temporalSelector;
+
+    /**
+     * The subject of comparison against the list of {@code fields}.
+     *
+     * @var string
+     */
+    private $value;
+
+    private function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Create a new {@link AnnotationQueryBuilder} that searches annotation bodies.
+     *
+     * @return AnnotationQueryBuilder
+     */
+    public static function byBody()
+    {
+        return new self(static::SEARCH_BODY_SERVICE_PATH);
+    }
+
+    /**
+     * Create a new {@link AnnotationQueryBuilder} that searches annotation targets.
+     *
+     * @return AnnotationQueryBuilder
+     */
+    public static function byTarget()
+    {
+        return new self(static::SEARCH_TARGET_SERVICE_PATH);
+    }
+
+    public function build(): string
+    {
+        Assertion::notEmpty($this->fields, "Must specify fields for an annotation query");
+        Assertion::allInArray($this->fields, ['id', 'source'], "Invalid fields given.  Expected 'id' or 'source'");
+        Assertion::notNull($this->value, "Must specify a search term for an annotation query");
+
+        $parameters = [
+            'fields' => implode($this->fields, ','),
+            'value' => $this->value,
+            'strict' => $this->strict ? 'true' : 'false',
+            't' => $this->temporalSelector,
+            'xywh' => $this->spatialSelector,
+            'generator' => $this->generator,
+            'creator' => $this->creator
+        ];
+
+        return $this->path . '?' . http_build_query($parameters);
+    }
+
+    private function field($id, string $value)
+    {
+        $this->fields = is_array($id) ? $id : [$id];
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Filter this query by annotations that have the given creator.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withCreator(string $value)
+    {
+        $this->creator = $value;
+        return $this;
+    }
+
+    /**
+     * Filter this query by annotations that have the given generator.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withGenerator(string $value)
+    {
+        $this->generator = $value;
+        return $this;
+    }
+
+    /**
+     * Filter this query by annotations having the given {@code id} value.
+     *
+     * @param string $value
+     * @return AnnotationQueryBuilder
+     */
+    public function withId(string $value)
+    {
+        return $this->field('id', $value);
+    }
+
+    /**
+     * Filter this query by annotations having the given {@code source} value.
+     *
+     * @param string $value
+     * @return AnnotationQueryBuilder
+     */
+    public function withSource(string $value)
+    {
+        return $this->field('source', $value);
+    }
+
+    /**
+     * Filter this query by annotations which intersect with the given spatial selector.
+     *
+     * @param string $selector
+     * @return $this
+     */
+    public function withSpatialDimensions(string $selector)
+    {
+        $this->spatialSelector = $selector;
+        return $this;
+    }
+
+    /**
+     * Filter this query by annotations which intersect with the given temporal selector.
+     *
+     * @param string $selector
+     * @return $this
+     */
+    public function withTemporalDimensions(string $selector)
+    {
+        $this->temporalSelector = $selector;
+        return $this;
+    }
+}

--- a/src/Search/AnnotationQueryBuilder.php
+++ b/src/Search/AnnotationQueryBuilder.php
@@ -95,7 +95,7 @@ final class AnnotationQueryBuilder
         return new self(static::SEARCH_TARGET_SERVICE_PATH);
     }
 
-    public function build(): string
+    public function build(): ServiceQuery
     {
         Assertion::notEmpty($this->fields, "Must specify fields for an annotation query");
         Assertion::allInArray($this->fields, ['id', 'source'], "Invalid fields given.  Expected 'id' or 'source'");
@@ -111,7 +111,7 @@ final class AnnotationQueryBuilder
             'creator' => $this->creator
         ];
 
-        return $this->path . '?' . http_build_query($parameters);
+        return new ServiceQuery($this->path, $parameters);
     }
 
     private function field($id, string $value)

--- a/src/Search/AnnotationQueryBuilder.php
+++ b/src/Search/AnnotationQueryBuilder.php
@@ -97,9 +97,9 @@ final class AnnotationQueryBuilder
 
     public function build(): ServiceQuery
     {
+        Assertion::notNull($this->value, "Must specify a search term for an annotation query");
         Assertion::notEmpty($this->fields, "Must specify fields for an annotation query");
         Assertion::allInArray($this->fields, ['id', 'source'], "Invalid fields given.  Expected 'id' or 'source'");
-        Assertion::notNull($this->value, "Must specify a search term for an annotation query");
 
         $parameters = [
             'fields' => implode($this->fields, ','),
@@ -114,7 +114,7 @@ final class AnnotationQueryBuilder
         return new ServiceQuery($this->path, $parameters);
     }
 
-    private function field($id, string $value)
+    public function field($id, string $value)
     {
         $this->fields = is_array($id) ? $id : [$id];
         $this->value = $value;

--- a/src/Search/AuthorQueryBuilder.php
+++ b/src/Search/AuthorQueryBuilder.php
@@ -101,8 +101,8 @@ class AuthorQueryBuilder
 
     public function build(): ServiceQuery
     {
-        Assertion::notEmpty($this->levels);
-        Assertion::allInArray($this->levels, ['body', 'target', 'annotation']);
+        Assertion::notEmpty($this->levels, "Must provide search levels to query at");
+        Assertion::allInArray($this->levels, ['body', 'target', 'annotation'], 'Levels can only be one of: body, target, annotation');
         Assertion::notNull($this->type, 'Must provide a type to query by.');
         Assertion::notNull($this->value, 'Must provide a search term');
 

--- a/src/Search/AuthorQueryBuilder.php
+++ b/src/Search/AuthorQueryBuilder.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Elucidate\Search;
+
+use Assert\Assertion;
+
+class AuthorQueryBuilder
+{
+    use StrictQueryAware;
+
+    /**
+     * Relative path to the annotation creator search service.
+     */
+    const SEARCH_CREATOR_SERVICE_PATH = '/search/service/creator';
+
+    /**
+     * Relative path to the annotation generator search service.
+     */
+    const SEARCH_GENERATOR_SERVICE_PATH = '/search/service/generator';
+
+    /**
+     * The levels within an annotation to search for the {@code creator} or {@code generator}.
+     *
+     * @var string[]
+     */
+    private $levels = [];
+
+    /**
+     * The path of the author search service in use.
+     *
+     * @var string
+     */
+    private $path;
+
+    /**
+     * The type of field
+     *
+     * @var string
+     */
+    private $type;
+
+    /**
+     * The search term for this query.
+     *
+     * @var string
+     */
+    private $value;
+
+    /**
+     * AuthorQueryBuilder constructor.
+     * @param string $path
+     */
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Create a new query builder that searches by {@code creator}.
+     *
+     * @return AuthorQueryBuilder
+     */
+    public static function byCreator()
+    {
+        return new self(static::SEARCH_CREATOR_SERVICE_PATH);
+    }
+
+    /**
+     * Create a new query builder that searches by {@code generator}.
+     *
+     * @return AuthorQueryBuilder
+     */
+    public static function byGenerator()
+    {
+        return new self(static::SEARCH_GENERATOR_SERVICE_PATH);
+    }
+
+    /**
+     * Add a search level to this query builder.  Valid search levels are: 'annotation', 'body', and 'target'.  These
+     * reflect which part of the annotation will be searched for the search term.
+     *
+     * @param string $level
+     * @return $this
+     */
+    public function atLevel(string $level)
+    {
+        $this->levels[] = $level;
+        return $this;
+    }
+
+    public function build(): string
+    {
+        Assertion::notEmpty($this->levels);
+        Assertion::allInArray($this->levels, ['body', 'target', 'annotation']);
+        Assertion::notNull($this->type, 'Must provide a type to query by.');
+        Assertion::notNull($this->value, 'Must provide a search term');
+
+        $parameters = [
+            'levels' => implode($this->levels, ','),
+            'type' => $this->type,
+            'value' => $this->value,
+            'strict' => $this->strict ? 'true' : 'false'
+        ];
+
+        return $this->path . '?' . http_build_query($parameters);
+    }
+
+    private function with(string $field, string $value)
+    {
+        Assertion::null($this->type, "Already filtering by '{$this->type}', cant filter by another field");
+
+        $this->type = $field;
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Filter this query by {@code email} fields matching the given {@code value}.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withEmail(string $value)
+    {
+        return $this->with('email', $value);
+    }
+
+    /**
+     * Filter this query by {@code emailsha1} fields matching the given {@code value}.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withEmailSha1(string $value)
+    {
+        return $this->with('emailsha1', $value);
+    }
+
+    /**
+     * Filter this query by {@code id} fields matching the given {@code value}.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withId(string $value)
+    {
+        return $this->with('id', $value);
+    }
+
+    /**
+     * Filter this query by {@code name} fields matching the given {@code value}.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withName(string $value)
+    {
+        return $this->with('name', $value);
+    }
+
+    /**
+     * Filter this query by {@code nickname} fields matching the given {@code value}.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function withNickname(string $value)
+    {
+        return $this->with('nickname', $value);
+    }
+}

--- a/src/Search/AuthorQueryBuilder.php
+++ b/src/Search/AuthorQueryBuilder.php
@@ -11,12 +11,12 @@ class AuthorQueryBuilder
     /**
      * Relative path to the annotation creator search service.
      */
-    const SEARCH_CREATOR_SERVICE_PATH = '/search/service/creator';
+    const SEARCH_CREATOR_SERVICE_PATH = '/services/search/creator';
 
     /**
      * Relative path to the annotation generator search service.
      */
-    const SEARCH_GENERATOR_SERVICE_PATH = '/search/service/generator';
+    const SEARCH_GENERATOR_SERVICE_PATH = '/services/search/generator';
 
     /**
      * The levels within an annotation to search for the {@code creator} or {@code generator}.
@@ -88,7 +88,18 @@ class AuthorQueryBuilder
         return $this;
     }
 
-    public function build(): string
+    /**
+     * Make this search match at all levels of an annotation.
+     *
+     * @return $this
+     */
+    public function atAllLevels()
+    {
+        $this->levels = ['body', 'target', 'annotation'];
+        return $this;
+    }
+
+    public function build(): ServiceQuery
     {
         Assertion::notEmpty($this->levels);
         Assertion::allInArray($this->levels, ['body', 'target', 'annotation']);
@@ -102,7 +113,7 @@ class AuthorQueryBuilder
             'strict' => $this->strict ? 'true' : 'false'
         ];
 
-        return $this->path . '?' . http_build_query($parameters);
+        return new ServiceQuery($this->path, $parameters);
     }
 
     private function with(string $field, string $value)

--- a/src/Search/ServiceQuery.php
+++ b/src/Search/ServiceQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Elucidate\Search;
+
+class ServiceQuery implements SearchQuery
+{
+    /**
+     * @var string
+     */
+    private $servicePath;
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    public function __construct(string $servicePath, array $parameters)
+    {
+
+        $this->servicePath = $servicePath;
+        $this->parameters = $parameters;
+    }
+
+    public function __toString(): string
+    {
+    }
+}

--- a/src/Search/ServiceQuery.php
+++ b/src/Search/ServiceQuery.php
@@ -8,6 +8,7 @@ class ServiceQuery implements SearchQuery
      * @var string
      */
     private $servicePath;
+
     /**
      * @var array
      */
@@ -22,5 +23,6 @@ class ServiceQuery implements SearchQuery
 
     public function __toString(): string
     {
+        return $this->servicePath . '?' . http_build_query($this->parameters);
     }
 }

--- a/src/Search/StrictQueryAware.php
+++ b/src/Search/StrictQueryAware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Elucidate\Search;
+
+trait StrictQueryAware
+{
+    /**
+     * A flag indicating whether this query should be a strict comparison between {@code value} and the subject.
+     *
+     * @var bool
+     */
+    private $strict;
+
+    /**
+     * Toggles the strict flag of this query.  Iff a query is {@code strict} then only exact matches against {@code value}
+     * will be returned.
+     *
+     * @param bool $strict
+     * @return $this
+     */
+    public function strict(bool $strict)
+    {
+        $this->strict = $strict;
+        return $this;
+    }
+}

--- a/tests/src/Search/AnnotationQueryBuilderTest.php
+++ b/tests/src/Search/AnnotationQueryBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Elucidate\Search\AnnotationQueryBuilder;
+
+final class AnnotationQueryBuilderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedExceptionMessage Invalid fields given.  Expected 'id' or 'source'
+     * @expectedException \Exception
+     */
+    public function testItThrowsAnExceptionWithInvalidFields()
+    {
+        AnnotationQueryBuilder::byBody()
+            ->field('invalid_id', 'abc')
+            ->build();
+    }
+
+    /**
+     * @expectedExceptionMessage Must specify fields for an annotation query
+     * @expectedException \Exception
+     */
+    public function testItThrowsAnExceptionWithNoFields()
+    {
+        AnnotationQueryBuilder::byBody()
+            ->field([], 'abc')
+            ->build();
+    }
+
+    /**
+     * @expectedExceptionMessage Must specify a search term for an annotation query
+     * @expectedException \Exception
+     */
+    public function testItThrowsAnExceptionWithNoValue()
+    {
+        AnnotationQueryBuilder::byBody()
+            ->build();
+    }
+
+}

--- a/tests/src/Search/AuthorQueryBuilderTest.php
+++ b/tests/src/Search/AuthorQueryBuilderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Elucidate\Search\AuthorQueryBuilder;
+
+final class AuthorQueryBuilderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Must provide search levels to query at
+     */
+    public function testItThrowsExceptionWithNoLevels()
+    {
+        AuthorQueryBuilder::byGenerator()
+            ->withEmailSha1('abc123')
+            ->build();
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Levels can only be one of: body, target, annotation
+     */
+    public function testItThrowsExceptionAtInvalidLevel()
+    {
+        AuthorQueryBuilder::byGenerator()
+            ->atLevel('invalid_level')
+            ->withEmail('test@test.com')
+            ->build();
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Must provide a type to query by.
+     */
+    public function testItThrowsExceptionWithNoValue()
+    {
+        AuthorQueryBuilder::byCreator()
+            ->atAllLevels()
+            ->build();
+    }
+}

--- a/tests/src/Search/ServiceQueryTest.php
+++ b/tests/src/Search/ServiceQueryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Elucidate\Search\ServiceQuery;
+
+class ServiceQueryTest extends PHPUnit_Framework_TestCase
+{
+    public function testNullParametersAreNotIncluded()
+    {
+        $serviceQuery = new ServiceQuery('s', [
+            'abc' => null,
+            'def' => 'non-null'
+        ]);
+
+        $queryString = (string) $serviceQuery;
+        $this->assertNotContains('abc=', $queryString);
+    }
+
+    public function testEmptyParametersAreIncluded()
+    {
+        $serviceQuery = new ServiceQuery('s', [
+            'abc' => '',
+            'def' => 'non-empty'
+        ]) ;
+
+        $queryString = (string) $serviceQuery;
+        $this->assertContains('abc=', $queryString);
+    }
+
+    public function testParametersAreEncoded()
+    {
+        $serviceQuery = new ServiceQuery('s', [
+            'abc' => 'a b',
+        ]);
+
+        $queryString = (string) $serviceQuery;
+        $this->assertContains('abc=a+b', $queryString);
+    }
+}


### PR DESCRIPTION
Adds several type-safe query builders to expose the full search endpoint exposed by elucidate.